### PR TITLE
SDL decoupling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ outputDir=./build
 CXXFLAGS=-fPIC -g -std=c++17
 WarningFlags=-Wpedantic -Wall -Wextra -Wfloat-equal
 LDFLAGS=-lSDL2 -lSDL2main -lSDL2_image -lSDL2_ttf -lSDL2_mixer -lSDL2_gfx
-CPPFLAGS=-DDEBUG
+CPPFLAGS=-DDEBUG -DLIB_SDL
 INCLUDES=-I./include
 LIBFILE=libbirb2d.so
 DESTDIR=/usr

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ outputDir=./build
 CXXFLAGS=-fPIC -g -std=c++17
 WarningFlags=-Wpedantic -Wall -Wextra -Wfloat-equal
 LDFLAGS=-lSDL2 -lSDL2main -lSDL2_image -lSDL2_ttf -lSDL2_mixer -lSDL2_gfx
-CPPFLAGS=-DDEBUG -DNO_SOUND #-DLIB_SDL
+CPPFLAGS=-DDEBUG -DLIB_SDL #-DNO_SOUND 
 INCLUDES=-I./include
 LIBFILE=libbirb2d.so
 DESTDIR=/usr

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ outputDir=./build
 CXXFLAGS=-fPIC -g -std=c++17
 WarningFlags=-Wpedantic -Wall -Wextra -Wfloat-equal
 LDFLAGS=-lSDL2 -lSDL2main -lSDL2_image -lSDL2_ttf -lSDL2_mixer -lSDL2_gfx
-CPPFLAGS=-DDEBUG -DLIB_SDL
+CPPFLAGS=-DDEBUG -DNO_SOUND #-DLIB_SDL
 INCLUDES=-I./include
 LIBFILE=libbirb2d.so
 DESTDIR=/usr

--- a/include/Audio.hpp
+++ b/include/Audio.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
+#ifndef NO_SOUND
 #include <iostream>
+
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mixer.h>
+#endif /* LIB_SDL */
 
 namespace Birb
 {
@@ -18,7 +22,9 @@ namespace Birb
 			void play();
 			void free()
 			{
+#ifdef LIB_SDL
 				Mix_FreeChunk(sound);
+#endif /* LIB_SDL */
 			}
 			bool isPlaying();
 
@@ -28,7 +34,9 @@ namespace Birb
 				free();
 			}
 		private:
+#ifdef LIB_SDL
 			Mix_Chunk* sound;
+#endif /* LIB_SDL */
 			std::string filePath;
 		};
 
@@ -41,7 +49,9 @@ namespace Birb
 			void play(bool loop);
 			void free()
 			{
+#ifdef LIB_SDL
 				Mix_FreeMusic(music);
+#endif /* LIB_SDL */
 			}
 			bool isPlaying();
 
@@ -51,9 +61,11 @@ namespace Birb
 				free();
 			}
 		private:
+#ifdef LIB_SDL
 			Mix_Music* music;
+#endif /* LIB_SDL */
 			std::string filePath;
 		};
 	};
-
 }
+#endif /* NO_SOUND */

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
+#endif
 
 namespace Birb
 {
@@ -11,10 +13,15 @@ namespace Birb
 		Color(const int& r, const int& g, const int& b, const int& a);
 		Color(const int& hex);
 
+#ifdef LIB_SDL
 		SDL_Color sdl() const; ///< Convert Color to SDL_Color
+		Uint8 r, g, b, a;
+#else
+		int r, g, b, a;
+#endif /* LIB_SDL */
+
 		void ChangeIntensity(const int& delta);
 
-		Uint8 r, g, b, a;
 
 		bool operator==(const Color& other) const
 		{

--- a/include/Entity.hpp
+++ b/include/Entity.hpp
@@ -10,6 +10,10 @@
 #include "Rect.hpp"
 #include "SceneObject.hpp"
 
+#ifndef LIB_SDL
+#include <Texture.hpp>
+#endif
+
 namespace Birb
 {
 	namespace EntityComponent
@@ -126,10 +130,18 @@ namespace Birb
 		Entity();
 		Entity(const std::string& p_name); ///< Creates an empty Entity object
 		Entity(const std::string& p_name, const Rect& rect); ///< Creates an empty Entity object with size and position
+
+#ifdef LIB_SDL
 		Entity(const std::string& p_name, const Rect& p_rect, SDL_Texture* p_texture); 			///< Creates an Entity with a SDL_Texture to render with custom scale
-		Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture, const EntityComponent::Animation& p_animationComponent); 	///< Creates a Animation Entity using a Animation
-		Entity(const std::string& p_name, const Vector2int& pos, const EntityComponent::Text& p_textComponent); 	///< Creates a Text Entity using a Text
 		Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture); 		///< Creates an Entity with a SDL_Texture to render without specifying a scale
+		Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture, const EntityComponent::Animation& p_animationComponent); 	///< Creates a Animation Entity using a Animation
+#else
+		Entity(const std::string& p_name, const Rect& p_rect, Texture texture);
+		Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture);
+		Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture, const EntityComponent::Animation& p_animationComponent);
+#endif /* LIB_SDL */
+
+		Entity(const std::string& p_name, const Vector2int& pos, const EntityComponent::Text& p_textComponent); 	///< Creates a Text Entity using a Text
 
 		/* Make it possible to update the Text */
 		void SetText(const std::string& newText); 	///< Change the text in Text and reload the sprite
@@ -139,7 +151,12 @@ namespace Birb
 		std::string name; 		///< Name of the entity. Used for debugging
 
 		/* Sprite handlings */
+		// TODO: Switch to the Texture class to avoid hardcoding SDL
+#ifdef LIB_SDL
 		SDL_Texture* sprite; 	///< Sprite to be rendered
+#else
+		Texture sprite; 		///< Sprite to be rendered
+#endif /* LIB_SDL */
 
 		float angle; 			///< Sets the rotation of the entity when rendering it
 		Rect rect; 				///< Sets the position and the dimensions of the entity

--- a/include/Font.hpp
+++ b/include/Font.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef LIB_SDL
 #include <SDL2/SDL_ttf.h>
+#endif
+
 #include <string>
 
 namespace Birb
@@ -15,7 +18,10 @@ namespace Birb
 
 		void LoadFont(const std::string& filePath, const int& fontSize = 12);
 		bool isLoaded() const;
+
+#ifdef LIB_SDL
 		TTF_Font* ttf() const;
+#endif
 
 		int GetSize() const;
 		void SetSize(const int& size);
@@ -23,7 +29,10 @@ namespace Birb
 	private:
 		int size;
 		bool fontLoaded;
+
+#ifdef LIB_SDL
 		TTF_Font* ttfFont;
 		void InitSDL_ttf(); ///< Initializes SDL2_ttf (if its not already initialized)
+#endif /* LIB_SDL */
 	};
 }

--- a/include/Rect.hpp
+++ b/include/Rect.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
+#endif
+
 #include "Color.hpp"
 #include "Polygon.hpp"
 #include "SceneObject.hpp"
@@ -18,7 +21,10 @@ namespace Birb
 		std::string toString() const;
 		Polygon toPolygon() const;
 		Rect getInt() const;
+
+#ifdef LIB_SDL
 		SDL_Rect getSDLRect() const;
+#endif
 
 		float x, y, w, h;
 		Color color;

--- a/include/Renderwindow.hpp
+++ b/include/Renderwindow.hpp
@@ -23,8 +23,10 @@ namespace Birb
 		Window(const std::string& p_title, const Vector2int& p_window_dimensions, const int& p_refresh_rate, const bool& resizable); ///< Creates a window and initializes SDL2 stuff and a renderer
 
 		/* -- Init stuff functions -- */
+#ifdef LIB_SDL
 		static void InitSDL(); ///< Initializes SDL2 (if its not already initialized)
 		static void InitSDL_image(); ///< Initializes SDL2_image (if its not already initialized)
+#endif /* LIB_SDL */
 		/* -------------------------- */
 
 		/* -- Rendering and cleanup functions -- */
@@ -39,16 +41,20 @@ namespace Birb
 
 		/* -- Basic window events -- */
 		void SetWindowSize(const Vector2int& dimensions);
-		void EventTick(const SDL_Event& event, bool* GameRunning);
 		bool PollEvents(); ///< Runs SDL_PollEvent and saves the result to the *event* variable
+#ifdef LIB_SDL
+		void EventTick(const SDL_Event& event, bool* GameRunning);
 		SDL_Event event;
+#endif /* LIB_SDL */
 		/* ------------------------- */
 
 		/* -- Window variables -- */
 		std::string win_title; ///< Window title text
 		int refresh_rate; ///< Window refreshrate. Can be changed during runtime if needed for some reason
+#ifdef LIB_SDL
 		SDL_Window* win;
 		SDL_Renderer* renderer;
+#endif /* LIB_SDL */
 		Vector2int dimensions; ///< Current window dimensions
 		Vector2int original_window_dimensions; ///< Window dimensions on application startup before its modified by the user
 		Vector2f window_dimensions_multiplier(); ///< Returns the difference between the current and original window dimensions.

--- a/include/Renderwindow.hpp
+++ b/include/Renderwindow.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL2_gfxPrimitives.h>
+#endif /* LIB_SDL */
 
 #include "Circle.hpp"
 #include "Color.hpp"
@@ -59,19 +61,25 @@ namespace Birb
 	/// Methods for loading different resources like fonts and textures
 	struct Resources
 	{
+#ifdef LIB_SDL
 		static SDL_Texture* LoadTexture(const std::string& p_filePath);
 
 		/* FIXME: Move all of this to resources.cpp and add constructors for wrapped boolean */
 		static SDL_Texture* TextSprite(const std::string& text, const Font& font, const Color& color, int wrapLength = 0);
 		static SDL_Texture* TextSprite(const std::string& text, const Font& font, const Color& color, const Color& bgColor);
 		static Uint8* 		CopyTexturePixels(SDL_Surface* surface, int* width, int* height, int* pitch);
+#endif /* LIB_SDL */
 	};
 
 	/// Methods for rendering things
 	namespace Render
 	{
 		bool DrawEntity(Entity& entity); ///< Renders an entity
+
+#ifdef LIB_SDL
 		void ResetDrawColor(); ///< Resets the drawing color back to black, so that the window background color stays the same
+		void SetRenderDrawColor(const Color& color); ///< Sets the drawing color for base SDL2 drawing functions
+#endif
 
 		void DrawRect(const Color& color, const Rect& dimensions); ///< Draw filled rect
 		void DrawRect(const Color& color, const Rect& dimensions, const int& width); ///< Draw hollow rect
@@ -93,6 +101,5 @@ namespace Birb
 		bool DrawPolygon(const Color& color, const std::vector<Vector2f>& points); ///< Draw a polygon from multiple points
 		bool DrawPolygon(const Polygon& polygon); ///< Draw a polygon
 
-		void SetRenderDrawColor(const Color& color); ///< Sets the drawing color for base SDL2 drawing functions
 	};
 }

--- a/include/Resources.hpp
+++ b/include/Resources.hpp
@@ -2,7 +2,9 @@
 
 #include <string>
 //#include <SDL2/SDL.h>
+#ifdef LIB_SDL
 #include <SDL2/SDL_ttf.h>
+#endif
 
 #include "Values.hpp"
 
@@ -11,9 +13,11 @@ namespace Birb
 	/// Methods for loading different resources like fonts and textures
 	struct Resources
 	{
+#ifdef LIB_SDL
 		static SDL_Texture* LoadTexture(const std::string& p_filePath);
 		static SDL_Texture* TextSprite(const std::string& text, TTF_Font* font, const SDL_Color& color);
 		static SDL_Texture* TextSprite(const std::string& text, TTF_Font* font, const SDL_Color& color, const SDL_Color& bgColor);
 		static Uint8* 		CopyTexturePixels(SDL_Surface* surface, int* width, int* height, int* pitch);
+#endif /* LIB_SDL */
 	};
 }

--- a/include/Texture.hpp
+++ b/include/Texture.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef LIB_SDL
 #include <SDL2/SDL_image.h>
+#endif
+
 #include <string>
 #include "Vector.hpp"
 
@@ -14,15 +17,20 @@ namespace Birb
 		//~Texture();
 
 		bool LoadTexture(const std::string& filePath);
-		bool CreateFromSurface(SDL_Renderer* renderer, SDL_Surface* surface);
 		bool isLoaded() const;
-		SDL_Texture* sdlTexture() const;
 		void Destroy();
+
 		Vector2int dimensions() const;
+#ifdef LIB_SDL
+		SDL_Texture* sdlTexture() const;
+		bool CreateFromSurface(SDL_Renderer* renderer, SDL_Surface* surface);
+#endif
 
 	private:
 		Vector2int texture_dimensions;
+#ifdef LIB_SDL
 		SDL_Texture* sdlTex;
+#endif
 		bool textureLoaded;
 	};
 }

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -1,7 +1,12 @@
 #pragma once
 #pragma GCC diagnostic ignored "-Wunused-function"
 
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
+#else
+#include <Logger.hpp>
+#endif
+
 #include <cstdlib>
 #include <math.h>
 
@@ -13,6 +18,7 @@ namespace Birb
 {
 	namespace utils
 	{
+#ifdef LIB_SDL
 		inline float hireTimeInSeconds()
 		{
 			float t = SDL_GetTicks();
@@ -23,6 +29,14 @@ namespace Birb
 
 		Vector2int GetTextureDimensions(SDL_Texture* texture);
 		SDL_Color TexturePixelToColor(Uint8* pixels, const Vector2int& pixelPosition, const int& textureWidth);
+#else
+		inline float hireTimeInSeconds()
+		{
+			Debug::Log("Implement hireTimeInSeconds()", Debug::fixme);
+			return 0;
+		}
+#endif /* LIB_SDL */
+
 		std::vector<Vector2int> SortPath(const Vector2int& startPoint, const std::vector<Vector2int>& points);
 		std::string CleanDecimals(const double& value); ///< Returns a string with without trailing zeroes in decimals
 

--- a/include/Values.hpp
+++ b/include/Values.hpp
@@ -1,7 +1,10 @@
 #pragma once
 #pragma GCC diagnostic ignored "-Wunused-variable"
 
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
+#endif
+
 #include <string>
 #include "Color.hpp"
 
@@ -30,8 +33,12 @@ namespace Birb
 		struct RenderVars
 		{
 			static inline int RefreshRate = 240;
+
+#ifdef LIB_SDL
 			static inline SDL_Window* MainWindow = NULL;
 			static inline SDL_Renderer* Renderer = NULL;
+#endif
+
 			static inline Color BackgroundColor = Color(0, 0, 0);
 		};
 	}

--- a/include/Values.hpp
+++ b/include/Values.hpp
@@ -24,10 +24,12 @@ namespace Birb
 	{
 		struct IsInit
 		{
+#ifdef LIB_SDL
 			static inline bool SDL = false;
 			static inline bool SDL_ttf = false;
 			static inline bool SDL_image = false;
 			static inline bool SDL_mixer = false;
+#endif /* LIB_SDL */
 		};
 
 		struct RenderVars
@@ -37,7 +39,7 @@ namespace Birb
 #ifdef LIB_SDL
 			static inline SDL_Window* MainWindow = NULL;
 			static inline SDL_Renderer* Renderer = NULL;
-#endif
+#endif /* LIB_SDL */
 
 			static inline Color BackgroundColor = Color(0, 0, 0);
 		};

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_SOUND
 #include "Audio.hpp"
 #include "Logger.hpp"
 #include "Values.hpp"
@@ -8,13 +9,14 @@ namespace Birb
 	//** Initializes the SDL_mixer library. Needs to be called before any other audio features are used
 	bool Audio::Init(int flags)
 	{
+#ifdef LIB_SDL
 		if (Global::IsInit::SDL_mixer)
 			return true;
 
 #ifdef DEBUG
 		if (Diagnostics::Debugging::InitMessages)
 			Debug::Log("Initializing audio...");
-#endif
+#endif /* DEBUG */
 
 		int initted = Mix_Init(flags);
 		if ((initted&flags) != flags)
@@ -40,9 +42,12 @@ namespace Birb
 #ifdef DEBUG
 		if (Diagnostics::Debugging::InitMessages)
 			Debug::Log("Audio initialized successfully!");
-#endif
+#endif /* DEBUG */
 
 		Global::IsInit::SDL_mixer = true;
+#else /* LIB_SDL */
+		Debug::Log("Audio not implemented without SDL_mixer!", Debug::fixme);
+#endif /* LIB_SDL */
 		return true;
 	}
 
@@ -51,12 +56,14 @@ namespace Birb
 	:filePath(p_filePath)
 	{
 		Audio::Init(0);
+#ifdef LIB_SDL
 		music = Mix_LoadMUS(p_filePath.c_str());
 		if (!music)
 		{
 			Debug::Log("Error loading music file [" + p_filePath + "] Error: " + (std::string)Mix_GetError(), Debug::error);
 			return;
 		}
+#endif /* LIB_SDL */
 	}
 
 	//** Loads up a sound file from given path. Used for shorter sound effects and not music
@@ -64,12 +71,14 @@ namespace Birb
 	:filePath(p_filePath)
 	{
 		Audio::Init(0);
+#ifdef LIB_SDL
 		sound = Mix_LoadWAV(p_filePath.c_str());
 		if (!sound)
 		{
 			Debug::Log("Error loading sound file [" + p_filePath + "] Error: " + (std::string)Mix_GetError(), Debug::error);
 			return;
 		}
+#endif /* LIB_SDL */
 	}
 
 	void Audio::MusicFile::play(bool loop)
@@ -80,41 +89,56 @@ namespace Birb
 		else
 			loopValue = 0;
 
+#ifdef LIB_SDL
 		if (Mix_PlayMusic(music, loopValue) == -1)
 		{
 			Debug::Log("Error playing music file [" + filePath + "] Error: " + Mix_GetError(), Debug::error);
 		}
+#endif /* LIB_SDL */
 	}
 
 	void Audio::MusicFile::play()
 	{
+#ifdef LIB_SDL
 		if (Mix_PlayMusic(music, 0) == -1)
 		{
 			Debug::Log("Error playing music file [" + filePath + "] Error: " + (std::string)Mix_GetError(), Debug::error);
 		}
+#endif /* LIB_SDL */
 	}
 
 	void Audio::SoundFile::play()
 	{
+#ifdef LIB_SDL
 		if (Mix_PlayChannel(-1, sound, 0) == -1)
 		{
 			Debug::Log("Error playing sound file [" + filePath + "] Error: " + (std::string)Mix_GetError(), Debug::error);
 		}
+#endif /* LIB_SDL */
 	}
 
 	bool Audio::MusicFile::isPlaying()
 	{
+#ifdef LIB_SDL
 		if (Mix_PlayingMusic())
 			return true;
 		else
 			return false;
+#else
+		return false;
+#endif /* LIB_SDL */
 	}
 
 	bool Audio::SoundFile::isPlaying()
 	{
+#ifdef LIB_SDL
 		if (Mix_Playing(-1) > 0)
 			return true;
 		else
 			return false;
+#else
+		return false;
+#endif /* LIB_SDL */
 	}
 }
+#endif /* NO_SOUND */

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -28,11 +28,13 @@ namespace Birb
 		a = 255;
 	}
 
+#ifdef LIB_SDL
 	SDL_Color Color::sdl() const
 	{
 		SDL_Color color = { r, g, b, a };
 		return color;
 	}
+#endif /* LIB_SDL */
 
 	void Color::ChangeIntensity(const int& delta)
 	{

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -173,7 +173,12 @@ namespace Birb
 
 		int texWidth;
 		int texHeight;
+#ifdef LIB_SDL
 		SDL_QueryTexture(sprite, NULL, NULL, &texWidth, &texHeight);
+#else
+		texWidth = sprite.dimensions().x;
+		texHeight = sprite.dimensions().y;
+#endif
 
 		int spritesPerRow = texWidth / animationComponent.spriteSize.x;
 		float fullRowCount = std::floor(index / spritesPerRow);
@@ -226,7 +231,11 @@ namespace Birb
 
 	void Entity::CenterRelativeTo(const Rect& rect)
 	{
+#ifdef LIB_SDL
 		Vector2int textureDimensions = utils::GetTextureDimensions(sprite);
+#else
+		Vector2int textureDimensions = sprite.dimensions();
+#endif
 		this->rect.x = ((rect.w / 2) - (textureDimensions.x / 2.0)) + rect.x;
 		this->rect.y = ((rect.h / 2) - (textureDimensions.y / 2.0)) + rect.y;
 	}
@@ -235,14 +244,18 @@ namespace Birb
 	{
 		name = "Default Entity";
 		SetBaseEntityValues();
+#ifdef LIB_SDL
 		sprite = nullptr;
+#endif
 	}
 
 	Entity::Entity(const std::string& p_name)
 	:name(p_name)
 	{
 		SetBaseEntityValues();
+#ifdef LIB_SDL
 		sprite = nullptr;
+#endif
 	}
 
 	/* FIXME: Write tests for this constructor */
@@ -250,40 +263,16 @@ namespace Birb
 	:name(p_name), rect(rect)
 	{
 		SetBaseEntityValues();
+#ifdef LIB_SDL
 		sprite = nullptr;
+#endif
 	}
 
+#ifdef LIB_SDL
 	Entity::Entity(const std::string& p_name, const Rect& p_rect, SDL_Texture* p_texture)
 	:name(p_name), sprite(p_texture), rect(p_rect)
 	{
 		SetBaseEntityValues();
-	}
-
-	Entity::Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture, const EntityComponent::Animation& p_animationComponent)
-	:name(p_name), sprite(p_texture)
-	{
-		/* Load the text sprite */
-		SetBaseEntityValues();
-		animationComponent = p_animationComponent;
-
-		rect.x = pos.x;
-		rect.y = pos.y;
-		rect.w = p_animationComponent.spriteSize.x;
-		rect.h = p_animationComponent.spriteSize.y;
-	}
-
-	Entity::Entity(const std::string& p_name, const Vector2int& pos, const EntityComponent::Text& p_textComponent)
-	:name(p_name)
-	{
-		/* Load the text sprite */
-		SetBaseEntityValues();
-		textComponent = p_textComponent;
-		sprite = nullptr;
-		LoadSprite();
-
-		rect.x = pos.x;
-		rect.y = pos.y;
-
 	}
 
 	Entity::Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture)
@@ -299,8 +288,58 @@ namespace Birb
 		rect.h = textureDimensions.y;
 	}
 
+	Entity::Entity(const std::string& p_name, const Vector2int& pos, SDL_Texture* p_texture, const EntityComponent::Animation& p_animationComponent)
+	:name(p_name), sprite(p_texture)
+	{
+		/* Load the text sprite */
+		SetBaseEntityValues();
+		animationComponent = p_animationComponent;
+
+		rect.x = pos.x;
+		rect.y = pos.y;
+		rect.w = p_animationComponent.spriteSize.x;
+		rect.h = p_animationComponent.spriteSize.y;
+	}
+#else
+	Entity::Entity(const std::string& p_name, const Rect& p_rect, Texture texture)
+	{
+		// TODO: Implement this function
+		Debug::Log("Implement Entity::Entity(const std::string& p_name, const Rect& p_rect, Texture texture)", Debug::fixme);
+	}
+
+	Entity::Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture)
+	{
+		// TODO: Implement this function
+		Debug::Log("Implement Entity::Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture)", Debug::fixme);
+	}
+
+	Entity::Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture, const EntityComponent::Animation& p_animationComponent)
+	{
+		// TODO: Implement this function
+		Debug::Log("Implement Entity::Entity(const std::string& p_name, const Vector2int& pos, Texture p_texture, const EntityComponent::Animation& p_animationComponent)", Debug::fixme);
+	}
+#endif /* LIB_SDL */
+
+	Entity::Entity(const std::string& p_name, const Vector2int& pos, const EntityComponent::Text& p_textComponent)
+	:name(p_name)
+	{
+		/* Load the text sprite */
+		SetBaseEntityValues();
+		textComponent = p_textComponent;
+#ifdef LIB_SDL
+		sprite = nullptr;
+#endif
+		LoadSprite();
+
+		rect.x = pos.x;
+		rect.y = pos.y;
+
+	}
+
+
 	void Entity::LoadSprite()
 	{
+#ifdef LIB_SDL
 		/* There's a text component. Let's generate a text sprite for it */
 		if (textComponent.text != "")
 		{
@@ -319,12 +358,19 @@ namespace Birb
 				rect.h = textureDimensions.y;
 			}
 		}
+#else
+		// TODO: Implement text component stuff without SDL
+#endif
 	}
 
 	void Entity::ReloadSprite()
 	{
 		/* Destroy the old sprite */
+#ifdef LIB_SDL
 		SDL_DestroyTexture(sprite);
+#else
+		sprite.Destroy();
+#endif
 
 		/* Create new text sprite */
 		LoadSprite();

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -45,6 +45,8 @@ namespace Birb
 			Debug::Log("Something went wrong when loading font '" + filePath + "' TTF_Error: " + (std::string)TTF_GetError(), Debug::error);
 			fontLoaded = false;
 		}
+#else
+		Debug::Log("Font loading not implemented without SDL_ttf", Debug::fixme);
 #endif /* LIB_SDL */
 	}
 

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -19,16 +19,22 @@ namespace Birb
 
 	Font::~Font()
 	{
+#ifdef LIB_SDL
 		TTF_CloseFont(ttfFont);
+#endif /* LIB_SDL */
 	}
 
 	void Font::LoadFont(const std::string& filePath, const int& fontSize)
 	{
+#ifdef LIB_SDL
 		InitSDL_ttf();
+#endif /* LIB_SDL */
+
 		this->filePath 	= filePath;
 		this->size 		= fontSize;
 		
 		/* Attempt to load the font */
+#ifdef LIB_SDL
 		ttfFont = TTF_OpenFont(filePath.c_str(), fontSize);
 		if (ttfFont != nullptr)
 		{
@@ -39,6 +45,7 @@ namespace Birb
 			Debug::Log("Something went wrong when loading font '" + filePath + "' TTF_Error: " + (std::string)TTF_GetError(), Debug::error);
 			fontLoaded = false;
 		}
+#endif /* LIB_SDL */
 	}
 
 	bool Font::isLoaded() const
@@ -46,10 +53,12 @@ namespace Birb
 		return fontLoaded;
 	}
 
+#ifdef LIB_SDL
 	TTF_Font* Font::ttf() const
 	{
 		return ttfFont;
 	}
+#endif /* LIB_SDL */
 
 	int Font::GetSize() const
 	{
@@ -61,10 +70,14 @@ namespace Birb
 		this->size = size;
 
 		/* Reload the font with a different size */
+#ifdef LIB_SDL
 		TTF_CloseFont(ttfFont);
+#endif /* LIB_SDL */
+
 		LoadFont(this->filePath, size);
 	}
 
+#ifdef LIB_SDL
 	void Font::InitSDL_ttf()
 	{
 		/* Check if SDL_ttf has already been initialized */
@@ -86,4 +99,5 @@ namespace Birb
 			Global::IsInit::SDL_ttf = true;
 		}
 	}
+#endif /* LIB_SDL */
 }

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -46,6 +46,7 @@ namespace Birb
 			fontLoaded = false;
 		}
 #else
+		fontLoaded = false;
 		Debug::Log("Font loading not implemented without SDL_ttf", Debug::fixme);
 #endif /* LIB_SDL */
 	}

--- a/src/rect.cpp
+++ b/src/rect.cpp
@@ -61,7 +61,7 @@ namespace Birb
 		sdlrect.y = y;
 		return sdlrect;
 	}
-#endif /* LIB_SDL  */
+#endif /* LIB_SDL */
 
 	void Rect::RenderFunc()
 	{

--- a/src/rect.cpp
+++ b/src/rect.cpp
@@ -51,6 +51,7 @@ namespace Birb
 		return roundedRect;
 	}
 
+#ifdef LIB_SDL
 	SDL_Rect Rect::getSDLRect() const
 	{
 		SDL_Rect sdlrect;
@@ -60,6 +61,7 @@ namespace Birb
 		sdlrect.y = y;
 		return sdlrect;
 	}
+#endif /* LIB_SDL  */
 
 	void Rect::RenderFunc()
 	{

--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -50,6 +50,8 @@ namespace Birb
 		/* Set some global rendering variables */
 		Global::RenderVars::MainWindow 	= win;
 		Global::RenderVars::Renderer 	= renderer;
+#else /* LIB_SDL */
+		Debug::Log("Most parts of the window system aren't implemented without SDL", Debug::fixme);
 #endif /* LIB_SDL */
 
 		Global::RenderVars::RefreshRate = refresh_rate;
@@ -115,7 +117,7 @@ namespace Birb
 #ifdef LIB_SDL
 #ifdef DEBUG
 		Debug::Log("Starting window cleanup for '" + win_title + "'...");
-#endif
+#endif /* DEBUG */
 		SDL_DestroyWindow(win);
 
 		/* FIXME: There's some sort of memory leak with SDL_Renderer. Destroying the renderer
@@ -146,7 +148,7 @@ namespace Birb
 
 #ifdef DEBUG
 		Debug::Log("Window '" + win_title + "' destroyed!");
-#endif
+#endif /* DEBUG */
 	}
 
 	void Window::Clear()
@@ -154,14 +156,14 @@ namespace Birb
 		/* Clear the window renderer. Call before rendering stuff */
 #ifdef LIB_SDL
 		SDL_RenderClear(Global::RenderVars::Renderer);
-#endif
+#endif /* LIB_SDL */
 	}
 
 	void Window::Display()
 	{
 #ifdef LIB_SDL
 		SDL_RenderPresent(Global::RenderVars::Renderer);
-#endif
+#endif /* LIB_SDL */
 	}
 
 	Vector2int Window::CursorPosition() const
@@ -169,9 +171,9 @@ namespace Birb
 		Vector2int pos;
 #ifdef LIB_SDL
 		SDL_GetMouseState(&pos.x, &pos.y);
-#else
+#else /* LIB_SDL */
 		Debug::Log("CursorPosition() not implemented", Debug::fixme);
-#endif
+#endif /* LIB_SDL */
 		return pos;
 	}
 
@@ -190,7 +192,7 @@ namespace Birb
 	{
 #ifdef LIB_SDL
 		SDL_SetWindowSize(win, dimensions.x, dimensions.y);
-#endif
+#endif /* LIB_SDL */
 		this->dimensions = dimensions;
 	}
 
@@ -226,13 +228,14 @@ namespace Birb
 	{
 #ifdef LIB_SDL
 		return (SDL_PollEvent(&event) != 0);
-#else
+#else /* LIB_SDL */
 		// TODO: Implement event polling without SDL
 		Debug::Log("Event polling not implemented", Debug::fixme);
 		return false;
 #endif /* LIB_SDL */
 	}
 
+// TODO: Move all of this code to a separate calls
 #ifdef LIB_SDL
 	SDL_Texture* Resources::LoadTexture(const std::string& p_filePath)
 	{
@@ -430,7 +433,7 @@ namespace Birb
 #else
 		Rect src;
 		Rect dst;
-#endif
+#endif /* LIB_SDL */
 		Vector2int centerPoint;
 
 		/* Get texture data */
@@ -449,7 +452,7 @@ namespace Birb
 				return false;
 			}
 		}
-#else
+#else /* LIB_SDL */
 		if (entity.sprite.isLoaded())
 		{
 			texWidth 	= entity.sprite.dimensions().x;
@@ -461,7 +464,7 @@ namespace Birb
 				return false;
 			}
 		}
-#endif
+#endif /* LIB_SDL */
 
 		if (entity.animationComponent.frameCount <= 0) /* Check if the entity has animations */
 		{
@@ -482,7 +485,7 @@ namespace Birb
 			HandleAnimations(&entity, &src, &dst);
 #else
 			// TODO: Figure out how to do animations without SDL
-#endif
+#endif /* LIB_SDL */
 		}
 
 		/* Check if the entity has an active progress bar component */
@@ -529,7 +532,7 @@ namespace Birb
 		{
 			SDL_SetRenderDrawColor(Global::RenderVars::Renderer, color.r, color.g, color.b, color.a);
 		}
-#endif
+#endif /* LIB_SDL */
 
 		void DrawRect(const Color& color, const Rect& dimensions)
 		{
@@ -538,9 +541,9 @@ namespace Birb
 			SDL_Rect rectangle = dimensions.getSDLRect();
 			SDL_RenderFillRect(Global::RenderVars::Renderer, &rectangle);
 			ResetDrawColor();
-#else
+#else /* LIB_SDL */
 			Debug::Log("DrawRect()", Debug::fixme);
-#endif
+#endif /* LIB_SDL */
 		}
 
 		void DrawRect(const Color& color, const Rect& dimensions, const int& width)
@@ -629,7 +632,7 @@ namespace Birb
 			ResetDrawColor();
 #else
 			Debug::Log("DrawLines()", Debug::fixme);
-#endif
+#endif /* LIB_SDL */
 		}
 
 		bool DrawCircle(const Circle& circle)
@@ -714,7 +717,7 @@ namespace Birb
 #else
 			Debug::Log("DrawPolygon()", Debug::fixme);
 			return false;
-#endif
+#endif /* LIB_SDL */
 		}
 
 		/* filledPolygonColor works only with integers, so this will just

--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -2,14 +2,19 @@
 #include "Values.hpp"
 #include "Logger.hpp"
 #include "Diagnostics.hpp"
+
+#ifdef LIB_SDL
 #include <SDL2/SDL_mixer.h>
+#endif
 
 namespace Birb
 {
 	Window::Window()
 	{
+#ifdef LIB_SDL
 		InitSDL();
 		InitSDL_image();
+#endif /* LIB_SDL */
 	}
 
 	Window::Window(const std::string& p_title, const Vector2int& p_window_dimensions, const int& p_refresh_rate, const bool& resizable)
@@ -59,6 +64,7 @@ namespace Birb
 		Cleanup();
 	}
 
+#ifdef LIB_SDL
 	void Window::InitSDL()
 	{
 		/* Check if SDL has already been initialized */
@@ -102,6 +108,7 @@ namespace Birb
 			Global::IsInit::SDL_image = true;
 		}
 	}
+#endif /* LIB_SDL */
 
 	void Window::Cleanup()
 	{
@@ -160,7 +167,11 @@ namespace Birb
 	Vector2int Window::CursorPosition() const
 	{
 		Vector2int pos;
+#ifdef LIB_SDL
 		SDL_GetMouseState(&pos.x, &pos.y);
+#else
+		Debug::Log("CursorPosition() not implemented", Debug::fixme);
+#endif
 		return pos;
 	}
 
@@ -177,7 +188,9 @@ namespace Birb
 
 	void Window::SetWindowSize(const Vector2int& dimensions)
 	{
+#ifdef LIB_SDL
 		SDL_SetWindowSize(win, dimensions.x, dimensions.y);
+#endif
 		this->dimensions = dimensions;
 	}
 
@@ -187,6 +200,7 @@ namespace Birb
 						(float)dimensions.y / (float)original_window_dimensions.y);
 	}
 
+#ifdef LIB_SDL
 	void Window::EventTick(const SDL_Event& event, bool* GameRunning)
 	{
 		switch (event.type)
@@ -206,6 +220,7 @@ namespace Birb
 				break;
 		}
 	}
+#endif /* LIB_SDL */
 
 	bool Window::PollEvents()
 	{
@@ -331,6 +346,7 @@ namespace Birb
 	}
 #endif /* LIB_SDL */
 
+#ifdef LIB_SDL
 	void HandleAnimations(Entity* entity, SDL_Rect* src, SDL_Rect* dst)
 	{
 		Vector2int atlasPos = entity->getAtlasPosition(entity->animationComponent.frameIndex);
@@ -374,6 +390,7 @@ namespace Birb
 			}
 		}
 	}
+#endif /* LIB_SDL */
 
 	void DrawProgressBar(const Entity& entity)
 	{

--- a/src/tests/audio_test.cpp
+++ b/src/tests/audio_test.cpp
@@ -1,3 +1,4 @@
+#ifndef NO_SOUND
 #include "Audio.hpp"
 #include "Logger.hpp"
 #include "Values.hpp"
@@ -9,24 +10,37 @@ namespace Birb
 	{
 		Birb::ApplicationInfo appInfo("Birb2D_tests");
 
+#ifdef LIB_SDL
         CHECK_FALSE(Global::IsInit::SDL_mixer);
+#endif /* LIB_SDL */
 		Audio::SoundFile sound(appInfo.ResLocation + "/audio/game_over.wav");
         // FIXME: Global is not being updated properly
+		
+#ifdef LIB_SDL
         CHECK(Global::IsInit::SDL_mixer);
+#endif /* LIB_SDL */
 
 		Audio::MusicFile music(appInfo.ResLocation + "/audio/score.wav");
 
 		Debug::Log("A sound should play now");
 		sound.play();
 		CHECK(sound.isPlaying());
+#ifdef LIB_SDL
 		SDL_Delay(1000);
+#endif /* LIB_SDL */
 
 		Debug::Log("Another sound should play now");
 		music.play();
 		CHECK(music.isPlaying());
+
+#ifdef LIB_SDL
 		SDL_Delay(1000);
+#endif /* LIB_SDL */
 
 		/* De-initialize SDL_mixer */
+#ifdef LIB_SDL
 		Mix_Quit();
+#endif /* LIB_SDL */
 	}
 }
+#endif /* NO_SOUND */

--- a/src/tests/color_test.cpp
+++ b/src/tests/color_test.cpp
@@ -55,6 +55,7 @@ namespace Birb
 		CHECK(colorC.a == 255);
 	}
 
+#ifdef LIB_SDL
 	TEST_CASE("Color to SDL_Color")
 	{
 		Color color(20, 45, 52, 10);
@@ -65,6 +66,7 @@ namespace Birb
 		CHECK(sdlcolor.b == 52);
 		CHECK(sdlcolor.a == 10);
 	}
+#endif /* LIB_SDL */
 
 	TEST_CASE("Color operator overloads")
 	{

--- a/src/tests/doctest_entry.cpp
+++ b/src/tests/doctest_entry.cpp
@@ -23,6 +23,8 @@ int main(int argc, char** argv)
 #include "Polygon.hpp"
 #include "Renderwindow.hpp"
 
+// This test is full of SDL stuff
+#ifdef LIB_SDL
 TEST_CASE("Window and rendering functions")
 {
 	Birb::ApplicationInfo appInfo("Birb2D_tests");
@@ -229,3 +231,4 @@ TEST_CASE("Window and rendering functions")
 
 	//SDL_Quit();
 }
+#endif /* LIB_SDL */

--- a/src/tests/renderwindow_test.cpp
+++ b/src/tests/renderwindow_test.cpp
@@ -17,9 +17,12 @@ namespace Birb
 		CHECK(window.win_title == "Birb2D tests");
 		CHECK(window.original_window_dimensions == Vector2int(1280, 720));
 
+#ifdef LIB_SDL
 		CHECK(Global::RenderVars::Renderer == window.renderer);
-		CHECK(Global::RenderVars::RefreshRate == 75);
 		CHECK(window.win == Global::RenderVars::MainWindow);
+#endif /* LIB_SDL */
+
+		CHECK(Global::RenderVars::RefreshRate == 75);
 		CHECK(Global::RenderVars::BackgroundColor == Colors::Black);
 	}
 
@@ -43,7 +46,10 @@ namespace Birb
 			{
 				while (window.PollEvents())
 				{
+					// SDL event polling, needs to be changed slightly to support GLFW
+#ifdef LIB_SDL
 					window.EventTick(window.event, &ApplicationRunning);
+#endif /* LIB_SDL */
 				}
 
 				timeStep.Step();
@@ -86,7 +92,11 @@ namespace Birb
 			/* Create the entities */
 			for (int i = 0; i < ENTITY_COUNT; i++)
 			{
+#ifdef LIB_SDL
 				Entity testEntity("Test entity", Vector2int(i * 70, 10), birbSprite.sdlTexture());
+#else
+				Entity testEntity("Test entity", Vector2int(i * 70, 10), birbSprite);
+#endif /* LIB_SDL */
 				entities.push_back(testEntity);
 			}
 

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -16,14 +16,20 @@ namespace Birb
 		textureLoaded = LoadTexture(filePath);
 		
 		/* If the texture was loaded successfully, get its dimensions */
+#ifdef LIB_SDL
 		if (textureLoaded)
 			texture_dimensions = utils::GetTextureDimensions(sdlTex);
 		else
 			texture_dimensions = Vector2int(0, 0);
+#else
+		// TODO: Figure out a way to get texture dimensions without SDL
+		Debug::Log("GetTextureDimensions() without SDL missing", Debug::fixme);
+#endif /* LIB_SDL */
 	}
 
 	bool Texture::LoadTexture(const std::string& filePath)
 	{
+#ifdef LIB_SDL
 		this->sdlTex = NULL;
 		
 		SDL_Surface* surface = IMG_Load(filePath.c_str());
@@ -38,6 +44,17 @@ namespace Birb
 
 		SDL_FreeSurface(surface);
 		return true;
+#else
+		// TODO: Texture loading without SDL
+		Debug::Log("Texture loading without SDL not implemented...", Debug::fixme);
+		return false;
+#endif /* LIB_SDL */
+	}
+
+#ifdef LIB_SDL
+	SDL_Texture* Texture::sdlTexture() const
+	{
+		return this->sdlTex;
 	}
 
 	bool Texture::CreateFromSurface(SDL_Renderer* renderer, SDL_Surface* surface)
@@ -54,16 +71,13 @@ namespace Birb
 			return true;
 		}
 	}
+#endif /* LIB_SDL */
 
 	bool Texture::isLoaded() const
 	{
 		return textureLoaded;
 	}
 
-	SDL_Texture* Texture::sdlTexture() const
-	{
-		return this->sdlTex;
-	}
 
 	void Texture::Destroy()
 	{

--- a/src/timestep.cpp
+++ b/src/timestep.cpp
@@ -1,4 +1,9 @@
+#ifdef LIB_SDL
 #include <SDL2/SDL.h>
+#else
+#include <Logger.hpp>
+#endif /* LIB_SDL */
+
 #include "Timestep.hpp"
 #include "Values.hpp"
 
@@ -12,7 +17,11 @@ namespace Birb
 
 	void TimeStep::Start()
 	{
+#ifdef LIB_SDL
 		startTick = SDL_GetTicks();
+#else
+		Debug::Log("Figure out an alternative for SDL_GetTicks()", Debug::fixme);
+#endif /* LIB_SDL */
 
 		double newTime = utils::hireTimeInSeconds();
 		double frameTime = newTime - currentTime;
@@ -37,9 +46,13 @@ namespace Birb
 
 	void TimeStep::End()
 	{
+#ifdef LIB_SDL
 		int frameTicks = SDL_GetTicks() - startTick;
 
 		if (frameTicks < 1000 / mainWindow->refresh_rate)
 			SDL_Delay(1000 / mainWindow->refresh_rate - frameTicks);
+#else
+		Debug::Log("Figure out an alternative for SDL_GetTicks() and SDL_Delay()", Debug::fixme);
+#endif /* LIB_SDL */
 	}
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -14,6 +14,7 @@ namespace Birb
 
 	void UI::PollButtons(const Window& window)
 	{
+#ifdef LIB_SDL
         /* Set the mouse down state */
         switch (window.event.type)
         {
@@ -61,5 +62,8 @@ namespace Birb
 			/* You can really only click one button at once, so lets stop if we got this far */
 			break;
 		}
+#else
+		Debug::Log("PollButtons() not fully implemented, because SDL_Event doesn't have non-SDL alternatives", Debug::fixme);
+#endif /* LIB_SDL */
 	}
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,7 @@ namespace Birb
 {
 	namespace utils
 	{
+#ifdef LIB_SDL
 		Vector2int GetTextureDimensions(SDL_Texture* texture)
 		{
 			Vector2int result;
@@ -24,6 +25,7 @@ namespace Birb
 			
 			return color;
 		}
+#endif /* LIB_SDL */
 
 		std::vector<Vector2int> SortPath(const Vector2int& startPoint, const std::vector<Vector2int>& points)
 		{


### PR DESCRIPTION
Bunch of ifdefs to separate SDL libraries from Birb2D. This is to allow for other OpenGL libraries (mostly looking at GLFW). SDL is quite restrictive and annoying to link against.

This is going to require bunch of changes to the abstraction layers so the switch between different libraries would be as seamless as possible